### PR TITLE
Fixed an unitialized pointer issue. Plugin works with Qt 5.13.1.

### DIFF
--- a/terminalwindow.h
+++ b/terminalwindow.h
@@ -37,12 +37,12 @@ private slots:
     void finishedInvoked();
 
 private:
-    QVBoxLayout *m_layout;
-    QTermWidget *m_termWidget;
-    QAction *m_copy;
-    QAction *m_paste;
-    QAction *m_close;
-    QWidget *m_parent;
+    QVBoxLayout *m_layout = nullptr;
+    QTermWidget *m_termWidget = nullptr;
+    QAction *m_copy = nullptr;
+    QAction *m_paste = nullptr;
+    QAction *m_close = nullptr;
+    QWidget *m_parent = nullptr;
 };
 
 class TerminalWindow : public Core::IOutputPane


### PR DESCRIPTION
There were some uninitialized pointers that were causing SEGFAULT's on Linux (I assume other platforms as well.)